### PR TITLE
Post-publish README edits

### DIFF
--- a/RAYCAST_README.md
+++ b/RAYCAST_README.md
@@ -1,0 +1,46 @@
+[Airtable](https://www.airtable.com) is a connected apps platform for building collaborative app. It allows you to create (data)bases to organize your data in tables and fields -- as well as build interfaces to display information to users and automations to automate processes.
+
+This extension uses Airtable's [OAuth support](https://airtable.com/developers/web/guides/oauth-integrations) ([beta as of November 2022](https://community.airtable.com/t/new-beta-new-api-authentication-methods-endpoints-and-public-api-docs/52714)) to allow a user to browse the bases, tables, fields, and views they granted the application access to (a part of the Airtable OAuth flow).
+
+---
+
+The software made available from this folder is not supported by Formagrid Inc (Airtable) or part of the Airtable Service. It is made available on an "as is" basis and provided without express or implied warranties of any kind.
+
+---
+
+The following GIF and screenshots show the functionality of this extension. Step by step instructions on how to install and configure the extension can be found below.
+
+| Description | Preview |
+|---|---|
+| List/filter bases | [![List/filter bases](./metadata/screenshot-0-list-all-bases.png)](./metadata/screenshot-0-list-all-bases.png) |
+| Deep link into API docs from list of bases | [![Deep link into API docs from list of bases](./metadata/screenshot-1-open-api-docs-for-base.png)](./metadata/screenshot-1-open-api-docs-for-base.png) |
+| List/filter a base's tables | [![List/filter a base's tables](./metadata/screenshot-2-browse-list-of-tables.png)](./metadata/screenshot-2-browse-list-of-tables.png) |
+| Preview base details including a list of tables, fields, and links to open the base and API docs in your browser | [![Preview base details including a list of tables, fields, and links to open the base and API docs in your browser](./metadata/screenshot-2c-base-details-view.png)](./metadata/screenshot-2c-base-details-view.png) |
+| List/filter a table's fields and copy/paste field IDs (similar functionality is available for a table's views) | [![List/filter a table's fields and copy/paste field IDs](./metadata/screenshot-3-list-fields-and-copy-id.png)](./metadata/screenshot-3-list-fields-and-copy-id.png) |
+
+
+## Setup
+
+1. **Install extensions**: Click the `Install Extension` button in the top right of [this page](https://www.raycast.com/marks/raycast-airtable-extension)
+
+2. **Authenticate with Airtable**: The first time you use the extension, you'll need to follow a few steps to authenticate with Airtable:
+
+    a.  Open the `List Airtable Bases` command in Raycast
+
+    b. Click `Sign in with Airtable` to securely connect the Raycast extension to your Airtable account using OAuth
+  
+    c. Follow the Airtable OAuth flow to authorize the Raycast extension to access `All current and future bases in all current and future workspaces`. You can choose only a specific base or workspace if you'd prefer.
+
+    d. You should be redirected by to Raycast and see a success message. After a few seconds, you will be sent to the result of the `List Airtable Bases` command you originally requested.
+
+    e. You're done! You can now use the `List Airtable Bases` command directly without going through these setup/configuration steps in the future)
+
+
+## Acknowledgement/Thank yous
+
+Many thanks to the following resources and people:
+
+- [Raycast OAuth extension examples](https://github.com/raycast/extensions/tree/main/examples/api-examples)
+- [Raycast Slack community](https://www.raycast.com/community)
+- Airtable Developer Platform & Ecosystem team
+- @marks and @SeanKeenan-at built this extension

--- a/RAYCAST_README.md
+++ b/RAYCAST_README.md
@@ -8,8 +8,6 @@ The software made available from this folder is not supported by Formagrid Inc (
 
 ---
 
-The following GIF and screenshots show the functionality of this extension. Step by step instructions on how to install and configure the extension can be found below.
-
 | Description | Preview |
 |---|---|
 | List/filter bases | [![List/filter bases](./metadata/screenshot-0-list-all-bases.png)](./metadata/screenshot-0-list-all-bases.png) |

--- a/README.md
+++ b/README.md
@@ -1,50 +1,16 @@
 # Airtable Raycast Extension
 
-This [Raycast](https://www.raycast.com/) Extension uses [Airtable](https://www.airtable.com)'s (beta as of November 2022) [OAuth support](https://airtable.com/developers/web/guides/oauth-integrations) to allow a user to browse the bases, tables, fields, and views they granted the application access to (a part of the Airtable OAuth flow).
+[Raycast](https://raycast.com) is an extendable alternative to Apple's Spotlight. 
 
-The following GIF and screenshots show the functionality of this extension.
+This extension uses Airtable's [OAuth support](https://airtable.com/developers/web/guides/oauth-integrations) ([beta as of November 2022](https://community.airtable.com/t/new-beta-new-api-authentication-methods-endpoints-and-public-api-docs/52714)) to allow a user to browse the bases, tables, fields, and views they granted the application access to (a part of the Airtable OAuth flow).
 
- [_Click here to skip past the screenshots to local setup instructions_](#local-setup-and-development).
 
-| Description | Preview |
-|---|---|
-| 20 second GIF (.mov) showing functionality highlights ([.mov version](./metadata/video-demo-20-seconds.mov)) | [![20 second video](./metadata/video-demo-20-seconds.gif)](./metadata/video-demo-20-seconds.gif) |
-| List/filter bases | [![List/filter bases](./metadata/screenshot-0-list-all-bases.png)](./metadata/screenshot-0-list-all-bases.png) |
-| Deep link into API docs from list of bases | [![Deep link into API docs from list of bases](./metadata/screenshot-1-open-api-docs-for-base.png)](./metadata/screenshot-1-open-api-docs-for-base.png) |
-| List/filter a base's tables | [![List/filter a base's tables](./metadata/screenshot-2-browse-list-of-tables.png)](./metadata/screenshot-2-browse-list-of-tables.png) |
-| Preview base details including a list of tables, fields, and links to open the base and API docs in your browser | [![Preview base details including a list of tables, fields, and links to open the base and API docs in your browser](./metadata/screenshot-2c-base-details-view.png)](./metadata/screenshot-2c-base-details-view.png) |
-| List/filter a table's fields and copy/paste field IDs (similar functionality is available for a table's views) | [![List/filter a table's fields and copy/paste field IDs](./metadata/screenshot-3-list-fields-and-copy-id.png)](./metadata/screenshot-3-list-fields-and-copy-id.png) |
+A GIF of the basic functionality is below. **[Follow this link to the Raycast extension store to install the extension.](https://www.raycast.com/marks/raycast-airtable-extension)**
+
+![20 second video demo](./metadata/video-demo-20-seconds.gif)
 
 ---
 
 The software made available from this folder is not supported by Formagrid Inc (Airtable) or part of the Airtable Service. It is made available on an "as is" basis and provided without express or implied warranties of any kind.
 
 ---
-
-## Local setup and development
-
-### A. How to install this extension
-
-At this time, this extension has not been published to the Raycast Extension Store. You'll need to follow the directions below to install it:
-
-1. Clone or download this repository
-2. Open the `Import Extension` command in Raycast and select the folder from step 1
-
-### B. How to configure/setup this extension
-
-The following steps are only required the first time you try to use the application:
-
-1. Open the `List Airtable Bases` command in Raycast
-2. Click `Sign in with Airtable` to securely connect the Raycast extension to your Airtable account using OAuth
-3. Follow the Airtable OAuth flow to authorize the Raycast extension to access `All current and future bases in all current and future workspaces`. You can choose only a specific workspace if you'd like.
-4. You should be redirected by to Raycast and see a success message. After a few seconds, you will be sent to the result of the `List Airtable Bases` command you originally requested (and you can now use that command directly without going through these setup/configuration seteps)
-
-
-## Acknowledgement/Thank yous
-
-Many thanks to the following resources and people:
-
-- [Raycast OAuth extension examples](https://github.com/raycast/extensions/tree/main/examples/api-examples)
-- [Raycast Slack community](https://www.raycast.com/community)
-- Airtable Developer Platform & Ecosystem team
-- @marks and @SeanKeenan-at built this extension

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "description": "List your Airtable bases and follow deep links to specific tables, views, or your base's API docs.",
   "icon": "airtable-logo.png",
   "author": "marks",
-  "contributors": ["SeanKeenan-Airtable"],
-  "categories": [ "Productivity" ],
+  "contributors": [
+    "SeanKeenan-Airtable"
+  ],
+  "categories": [
+    "Productivity"
+  ],
   "preferences": [
     {
       "type": "textfield",


### PR DESCRIPTION
Now that the extension is raycast.com/marks/raycast-airtable-extension, update the repo README and maintain a copy of the README shown on the extension store.